### PR TITLE
Force data from experiments.json to be actually parsed into json

### DIFF
--- a/experiment.html
+++ b/experiment.html
@@ -120,6 +120,7 @@
 
             $(document).ready(function () {
                 $.get('data/experiments.json', function (data) {
+					data = JSON.parse(data);
                     trialsData = data.experiments;
                     currentTrial = 0;
                     totalNumberOfTrials = trialsData.length;


### PR DESCRIPTION
Currently the `$.get('data/experiments.json')` returns a string, and not a JSON object. This causes `trialsData = data.experiments;` to assign `undefined` to trialsData, causing nothing to show up on the right pane.

This simple fix forces the read string to be parsed into a JSON object.